### PR TITLE
#149392 升級 commons-collections 避開 deserialization 風險

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
             <version>2.5.1</version>
         </dependency>
         <dependency>
+            <!-- #149332 overriding dbunit's vulnerable commons-collections -->
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.187</version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.cht.test</groupId>
     <artifactId>cht-test</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CHT Test Framework</name>


### PR DESCRIPTION
將 dbUnit 裡的 commons-collections 升版成 3.2.2。

議題: http://192.168.1.4/issues/149332
